### PR TITLE
Fix a few variadic parameter type docblock annotations

### DIFF
--- a/src/Functional/Compose.php
+++ b/src/Functional/Compose.php
@@ -27,7 +27,7 @@ use function Functional\id;
 /**
  * Return a new function that composes all functions in $functions into a single callable
  *
- * @param callable[] $functions
+ * @param callable ...$functions
  * @return callable
  * @todo Add callable typehint when HHVM supports use of typehints with variadic arguments
  * @see https://github.com/facebook/hhvm/issues/6954

--- a/src/Functional/PartialAny.php
+++ b/src/Functional/PartialAny.php
@@ -30,7 +30,7 @@ use Functional\Exceptions\InvalidArgumentException;
  * Use Functional\…, Functional\…() or Functional\placeholder() as a placeholder
  *
  * @param callable $callback
- * @param array $arguments
+ * @param mixed ...$arguments
  * @return callable
  */
 function partial_any(callable $callback, ...$arguments)


### PR DESCRIPTION
When running phan, the current annotations are interpreted as if each
parameter should be an array.  These annotation changes are in
accordance with
[https://github.com/phpDocumentor/ReflectionDocBlock/blob/14f9edf1ae14d6ce417afb05a9ed37d7b3cc341e/tests/unit/DocBlock/Tags/ParamTest.php#L152-L168],
and denote that each element should be of the given type.